### PR TITLE
Fix notification problem when the WAKE_LOCK permission is not granted

### DIFF
--- a/vector/src/main/java/im/vector/notifications/NotificationUtils.kt
+++ b/vector/src/main/java/im/vector/notifications/NotificationUtils.kt
@@ -567,11 +567,15 @@ object NotificationUtils {
             }
 
             // turn the screen on for 3 seconds
-            if (Matrix.getInstance(VectorApp.getInstance())!!.pushManager.isScreenTurnedOn) {
-                val pm = VectorApp.getInstance().getSystemService(Context.POWER_SERVICE) as PowerManager
-                val wl = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK or PowerManager.ACQUIRE_CAUSES_WAKEUP, "Tchap:manageNotificationSound")
-                wl.acquire(3000)
-                wl.release()
+            try {
+                if (Matrix.getInstance(VectorApp.getInstance())!!.pushManager.isScreenTurnedOn) {
+                    val pm = VectorApp.getInstance().getSystemService(Context.POWER_SERVICE) as PowerManager
+                    val wl = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK or PowerManager.ACQUIRE_CAUSES_WAKEUP, "Tchap:manageNotificationSound")
+                    wl.acquire(3000)
+                    wl.release()
+                }
+            } catch (e: Exception) {
+                Log.e(LOG_TAG, "## turnScreenOn() failed", e);
             }
         } else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -1623,11 +1623,15 @@ public class EventStreamService extends Service {
             mIncomingCallId = callId;
 
             // turn the screen on for 3 seconds
-            if (Matrix.getInstance(VectorApp.getInstance()).getPushManager().isScreenTurnedOn()) {
-                PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
-                PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP, "Tchap:MXEventListener");
-                wl.acquire(3000);
-                wl.release();
+            try {
+                if (Matrix.getInstance(VectorApp.getInstance()).getPushManager().isScreenTurnedOn()) {
+                    PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
+                    PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP, "Tchap:MXEventListener");
+                    wl.acquire(3000);
+                    wl.release();
+                }
+            } catch (Exception e) {
+                Log.e(LOG_TAG, "## turnScreenOn() failed", e);
             }
         } else {
             Log.d(LOG_TAG, "displayIncomingCallNotification : do not display the incoming call notification because there is a pending call");


### PR DESCRIPTION
The notifications are not displayed if all the following conditions are met:
- F-droid without VoIP flavor (without the WAKE_LOCK permission)
- application is running in background
- option "Turn screen on for 3 seconds" is set

This pull request catches the exception thrown by the `newWakeLock` call ASAP which permits the notification to appear.