### PR TITLE
Notification Privacy: the REDUCED privacy mode is removed in Tchap.

### DIFF
--- a/vector/src/main/java/im/vector/activity/NotificationPrivacyActivity.java
+++ b/vector/src/main/java/im/vector/activity/NotificationPrivacyActivity.java
@@ -61,8 +61,8 @@ public class NotificationPrivacyActivity extends VectorAppCompatActivity {
     @BindView(R.id.rb_notification_low_detail)
     RadioButton rbPrivacyLowDetail;
 
-    @BindView(R.id.rb_notification_reduce_privacy)
-    RadioButton rbPrivacyReduced;
+//    @BindView(R.id.rb_notification_reduce_privacy)
+//    RadioButton rbPrivacyReduced;
 
     /* ==========================================================================================
      * LifeCycle
@@ -131,10 +131,10 @@ public class NotificationPrivacyActivity extends VectorAppCompatActivity {
         updateNotificationPrivacy(PushManager.NotificationPrivacy.LOW_DETAIL);
     }
 
-    @OnClick(R.id.rly_reduced_privacy_notifications)
-    void onReducedPrivacyClick() {
-        updateNotificationPrivacy(PushManager.NotificationPrivacy.REDUCED);
-    }
+//    @OnClick(R.id.rly_reduced_privacy_notifications)
+//    void onReducedPrivacyClick() {
+//        updateNotificationPrivacy(PushManager.NotificationPrivacy.REDUCED);
+//    }
 
     /* ==========================================================================================
      * Private
@@ -159,7 +159,7 @@ public class NotificationPrivacyActivity extends VectorAppCompatActivity {
 
         rbPrivacyNormal.setChecked(notificationPrivacy == PushManager.NotificationPrivacy.NORMAL);
         rbPrivacyLowDetail.setChecked(notificationPrivacy == PushManager.NotificationPrivacy.LOW_DETAIL);
-        rbPrivacyReduced.setChecked(notificationPrivacy == PushManager.NotificationPrivacy.REDUCED);
+//        rbPrivacyReduced.setChecked(notificationPrivacy == PushManager.NotificationPrivacy.REDUCED);
     }
 
     private void doSetNotificationPrivacy(PushManager.NotificationPrivacy notificationPrivacy) {

--- a/vector/src/main/java/im/vector/push/PushManager.java
+++ b/vector/src/main/java/im/vector/push/PushManager.java
@@ -1073,9 +1073,11 @@ public final class PushManager {
 
         switch (notificationPrivacy) {
             case REDUCED:
-                setContentSendingAllowed(true);
-                setBackgroundSyncAllowed(false);
-                break;
+                // Tchap: prevent the user from returning in REDUCED mode (This should not happen
+                // according to the updated UI). Fallback to LOW_DETAIL by default.
+//                setContentSendingAllowed(true);
+//                setBackgroundSyncAllowed(false);
+//                break;
             case LOW_DETAIL:
                 setContentSendingAllowed(false);
                 setBackgroundSyncAllowed(false);

--- a/vector/src/main/java/im/vector/util/PreferencesManager.java
+++ b/vector/src/main/java/im/vector/util/PreferencesManager.java
@@ -35,7 +35,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import im.vector.Matrix;
 import im.vector.R;
+import im.vector.push.PushManager;
 import im.vector.repositories.ServerUrlsRepository;
 import im.vector.ui.themes.ThemeUtils;
 
@@ -281,6 +283,18 @@ public class PreferencesManager {
         PreferenceManager.getDefaultSharedPreferences(context)
                 .edit()
                 .putBoolean(DID_ASK_TO_IGNORE_BATTERY_OPTIMIZATIONS_KEY, true)
+                .apply();
+    }
+
+    /**
+     * Enable again the question to disable battery optimisations.
+     *
+     * @param context the context
+     */
+    public static void resetDidAskUserToIgnoreBatteryOptimizations(Context context) {
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .edit()
+                .putBoolean(DID_ASK_TO_IGNORE_BATTERY_OPTIMIZATIONS_KEY, false)
                 .apply();
     }
 
@@ -585,7 +599,16 @@ public class PreferencesManager {
      * Fix some migration issues
      */
     public static void fixMigrationIssues(Context context) {
-        // There is no migration issue for the moment in Tchap.
+        // Notification Privacy: the REDUCED privacy mode is removed in Tchap.
+        final PushManager pushManager = Matrix.getInstance(context).getPushManager();
+        PushManager.NotificationPrivacy notificationPrivacy = pushManager.getNotificationPrivacy();
+        if (notificationPrivacy == PushManager.NotificationPrivacy.REDUCED) {
+            // We fallback to the LOW_DETAIL mode by default
+            pushManager.setNotificationPrivacy(PushManager.NotificationPrivacy.LOW_DETAIL, null);
+            // and reset the "IgnoreBatteryOptimization" to invite again the user to use the NORMAL
+            // mode on VectorHomeActivity resume.
+            PreferencesManager.resetDidAskUserToIgnoreBatteryOptimizations(context);
+        }
     }
 
     /**

--- a/vector/src/main/res/layout/activity_notification_privacy.xml
+++ b/vector/src/main/res/layout/activity_notification_privacy.xml
@@ -226,59 +226,6 @@
                             android:textColor="@color/default_text_light_color_dark"
                             android:textSize="13sp" />
                     </RelativeLayout>
-
-                    <RelativeLayout
-                        android:id="@+id/rly_reduced_privacy_notifications"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_below="@id/rly_low_detail_notifications">
-
-                        <RadioButton
-                            android:id="@+id/rb_notification_reduce_privacy"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentStart="true"
-                            android:layout_alignParentLeft="true"
-                            android:layout_marginStart="3dp"
-                            android:layout_marginLeft="3dp"
-                            android:layout_marginTop="15dp"
-                            android:clickable="false" />
-
-                        <TextView
-                            android:id="@+id/tv_notification_reduce_privacy"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentStart="true"
-                            android:layout_alignParentLeft="true"
-                            android:layout_marginStart="40dp"
-                            android:layout_marginLeft="40dp"
-                            android:layout_marginTop="17dp"
-                            android:text="@string/settings_notification_privacy_reduced"
-                            android:textSize="20sp" />
-
-                        <TextView
-                            android:id="@+id/tv_notifications_fcm_reduced"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_below="@+id/tv_notification_reduce_privacy"
-                            android:layout_alignStart="@+id/tv_notification_reduce_privacy"
-                            android:layout_alignLeft="@+id/tv_notification_reduce_privacy"
-                            android:layout_marginTop="3dp"
-                            android:text="@string/settings_notification_privacy_fcm"
-                            android:textColor="@color/default_text_light_color_dark"
-                            android:textSize="13sp" />
-
-                        <TextView
-                            android:id="@+id/tv_notifications_metadata_reduced"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_below="@+id/tv_notifications_fcm_reduced"
-                            android:layout_alignStart="@+id/tv_notification_reduce_privacy"
-                            android:layout_alignLeft="@+id/tv_notification_reduce_privacy"
-                            android:text="@string/settings_notification_privacy_nosecure_message_content"
-                            android:textColor="@color/default_text_light_color_dark"
-                            android:textSize="13sp" />
-                    </RelativeLayout>
                 </RelativeLayout>
             </LinearLayout>
         </ScrollView>


### PR DESCRIPTION
We fallback to the LOW_DETAIL mode by default,
and reset the "IgnoreBatteryOptimization" to invite again the user to use the NORMAL mode on VectorHomeActivity resume.

#466 