### PR TITLE
Move to TLS 1.3

### DIFF
--- a/vector/src/main/java/fr/gouv/tchap/util/HomeServerConnectionConfigFactory.kt
+++ b/vector/src/main/java/fr/gouv/tchap/util/HomeServerConnectionConfigFactory.kt
@@ -21,6 +21,7 @@ import android.os.Build
 import android.support.annotation.VisibleForTesting
 import fr.gouv.tchap.config.CERTIFICATE_FINGERPRINT_LIST
 import fr.gouv.tchap.config.ENABLE_CERTIFICATE_PINNING
+import okhttp3.TlsVersion
 import org.matrix.androidsdk.HomeServerConnectionConfig
 import org.matrix.androidsdk.ssl.Fingerprint
 import java.lang.Long.parseLong
@@ -44,6 +45,14 @@ fun createHomeServerConnectionConfig(homeServerUrl: String, identityServerUrl: S
             .withTlsLimitations(true, Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT)
             .withPin(ENABLE_CERTIFICATE_PINNING)
             .build()
+            .cleanAcceptedTlsVersion()
+}
+
+/**
+ * Clean the accepted TLS version by removing the unaccepted versions (which were accepted previously).
+ */
+fun HomeServerConnectionConfig.cleanAcceptedTlsVersion() = apply {
+    acceptedTlsVersions?.remove(TlsVersion.TLS_1_2)
 }
 
 @VisibleForTesting

--- a/vector/src/main/java/im/vector/store/LoginStorage.java
+++ b/vector/src/main/java/im/vector/store/LoginStorage.java
@@ -29,6 +29,8 @@ import org.matrix.androidsdk.core.Log;
 import java.util.ArrayList;
 import java.util.List;
 
+import fr.gouv.tchap.util.HomeServerConnectionConfigFactoryKt;
+
 /**
  * Stores login credentials in SharedPreferences.
  */
@@ -70,7 +72,9 @@ public class LoginStorage {
 
             for (int i = 0; i < connectionConfigsStrings.length(); i++) {
                 configList.add(
-                        HomeServerConnectionConfig.fromJson(connectionConfigsStrings.getJSONObject(i))
+                        HomeServerConnectionConfigFactoryKt.cleanAcceptedTlsVersion(
+                                HomeServerConnectionConfig.fromJson(connectionConfigsStrings.getJSONObject(i))
+                        )
                 );
             }
 


### PR DESCRIPTION
- remove TLS 1.2 from the accepted versions list (at the new config creation, and on the stored configs)

#495