### PR TITLE
include 64bits version of the libraries in the APK

### DIFF
--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -44,17 +44,7 @@ android {
         vectorDrawables.useSupportLibrary = true
 
         ndk {
-            // abiFilters "arm64-v8a", "armeabi-v7a", "x86"
-            abiFilters "armeabi-v7a", "x86"
-        }
-
-        packagingOptions {
-            // The project react-native does not provide 64-bit binaries at the
-            // time of this writing. Unfortunately, packaging any 64-bit
-            // binaries into the .apk will crash the app at runtime on 64-bit
-            // platforms.
-            exclude "lib/x86_64/libjingle_peerconnection_so.so"
-            exclude "lib/arm64-v8a/libjingle_peerconnection_so.so"
+            abiFilters "armeabi-v7a", "x86", 'arm64-v8a', 'x86_64'
         }
 
         multiDexEnabled true


### PR DESCRIPTION
Required by the Google Play 64-bit requirement:

<img width="556" alt="Screenshot 2019-07-19 at 16 18 11" src="https://user-images.githubusercontent.com/8969772/61541947-e0f08a00-aa40-11e9-94c1-cae0656b0f75.png">

Note: the APK size is growing up due to this change. The version Tchap-agent without voip grows up from 12.2 MB to 14.6 MB.

The included libraries in this APK:
<img width="189" alt="Screenshot 2019-07-19 at 16 10 10" src="https://user-images.githubusercontent.com/8969772/61542137-3f1d6d00-aa41-11e9-8488-38709fb85346.png">
