### PR TITLE
BugFix - App crashes during `computeDisplayNameFromUserId`

### DIFF
--- a/vector/src/main/java/fr/gouv/tchap/util/DinsicUtils.java
+++ b/vector/src/main/java/fr/gouv/tchap/util/DinsicUtils.java
@@ -230,20 +230,24 @@ public class DinsicUtils {
                                 String[] subComponents = component.split("-");
                                 for (int i = 0; i < subComponents.length - 1; i++) {
                                     String subComponent = subComponents[i];
-                                    builder.append(subComponent.substring(0, 1).toUpperCase());
-                                    if (subComponent.length() > 1) {
-                                        builder.append(subComponent.substring(1));
+                                    if (!subComponent.isEmpty()) {
+                                        builder.append(subComponent.substring(0, 1).toUpperCase());
+                                        if (subComponent.length() > 1) {
+                                            builder.append(subComponent.substring(1));
+                                        }
+                                        builder.append("-");
                                     }
-                                    builder.append("-");
                                 }
                                 // Retrieve the last sub-component
                                 component = subComponents[subComponents.length - 1];
                             }
 
-                            // Capitalize the component (or the last sub-component)
-                            builder.append(component.substring(0, 1).toUpperCase());
-                            if (component.length() > 1) {
-                                builder.append(component.substring(1));
+                            if (!component.isEmpty()) {
+                                // Capitalize the component (or the last sub-component)
+                                builder.append(component.substring(0, 1).toUpperCase());
+                                if (component.length() > 1) {
+                                    builder.append(component.substring(1));
+                                }
                             }
                         }
                     }

--- a/vector/src/test/java/fr/gouv/tchap/util/DinsicUtilsTest.kt
+++ b/vector/src/test/java/fr/gouv/tchap/util/DinsicUtilsTest.kt
@@ -36,6 +36,11 @@ class DinsicUtilsTest {
         assertEquals("Jean Martin De-La-Rampe", DinsicUtils.computeDisplayNameFromUserId("@jean.martin.de-la-rampe-modernisation.gouv.fr:a.tchap.gouv.fr"))
     }
 
+    @Test
+    fun DinsicUtils_computeDisplayNameFromUserId_emptydashes() {
+        assertEquals("Jean Martin De-La-Rampe", DinsicUtils.computeDisplayNameFromUserId("@jean.martin.de--la--rampe-modernisation.gouv.fr:a.tchap.gouv.fr"))
+    }
+
     // It fails for the moment
     @Test
     fun DinsicUtils_computeDisplayNameFromUserId_dash_in_domain() {


### PR DESCRIPTION
The crash is observed when the user id contains empty string between '-' character.

#560 