### PR TITLE
Clean the Tchap-secure application

### DIFF
--- a/vector/src/main/java/fr/gouv/tchap/activity/TchapRoomCreationActivity.java
+++ b/vector/src/main/java/fr/gouv/tchap/activity/TchapRoomCreationActivity.java
@@ -160,6 +160,10 @@ public class TchapRoomCreationActivity extends MXCActionBarActivity {
 
         // Initialize default room params as private and restricted
         externalAccessRoomSwitch.setChecked(false);
+        if (DinumUtilsKt.isSecure()) {
+            // There is no external users on Tchap secure, so hide this option
+            externalAccessRoomSwitch.setVisibility(View.GONE);
+        }
         setRoomAccessRule(RoomAccessRulesKt.RESTRICTED);
         publicPrivateRoomSwitch.setChecked(false);
         mRoomParams.visibility = RoomDirectoryVisibility.DIRECTORY_VISIBILITY_PRIVATE;

--- a/vector/src/main/java/fr/gouv/tchap/fragments/TchapContactFragment.java
+++ b/vector/src/main/java/fr/gouv/tchap/fragments/TchapContactFragment.java
@@ -48,6 +48,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import butterknife.BindView;
+import fr.gouv.tchap.util.DinumUtilsKt;
 import im.vector.R;
 import im.vector.activity.VectorAppCompatActivity;
 import im.vector.activity.VectorRoomInviteMembersActivity;
@@ -139,8 +140,8 @@ public class TchapContactFragment extends AbsHomeFragment implements ContactsMan
             startRemoteKnownContactsSearch(true);
         }
 
-        // Hide Invite by email button for external users
-        if (DinsicUtils.isExternalTchapSession(mSession)) {
+        // Hide Invite by email button for Tchap-secure, and for external users on Tchap-agent
+        if (DinumUtilsKt.isSecure() || DinsicUtils.isExternalTchapSession(mSession)) {
             mInviteContactLayout.setVisibility(View.GONE);
         } else {
             mInviteContactLayout.setOnClickListener(new View.OnClickListener() {

--- a/vector/src/main/java/fr/gouv/tchap/util/DinumUtils.kt
+++ b/vector/src/main/java/fr/gouv/tchap/util/DinumUtils.kt
@@ -17,6 +17,7 @@
 package fr.gouv.tchap.util
 
 import fr.gouv.tchap.sdk.session.room.model.*
+import im.vector.BuildConfig
 import org.matrix.androidsdk.MXSession
 import org.matrix.androidsdk.core.Log
 import org.matrix.androidsdk.core.callback.ApiCallback
@@ -26,6 +27,14 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 
 private val LOG_TAG = "DinumUtils"
+
+//=============================================================================================
+// Target
+//=============================================================================================
+
+fun isSecure(): Boolean {
+    return BuildConfig.FLAVOR_target == "protecteed"
+}
 
 //=============================================================================================
 // Room messages retention

--- a/vector/src/main/java/im/vector/fragments/VectorRoomDetailsMembersFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorRoomDetailsMembersFragment.java
@@ -71,6 +71,7 @@ import java.util.TimerTask;
 
 import fr.gouv.tchap.sdk.session.room.model.RoomAccessRulesKt;
 import fr.gouv.tchap.util.DinsicUtils;
+import fr.gouv.tchap.util.DinumUtilsKt;
 import im.vector.R;
 import im.vector.activity.CommonActivityUtils;
 import im.vector.activity.MXCActionBarActivity;
@@ -895,14 +896,26 @@ public class VectorRoomDetailsMembersFragment extends VectorBaseFragment {
                 intent.putExtra(VectorRoomInviteMembersActivity.EXTRA_ROOM_ID, mRoom.getRoomId());
                 //intent.putExtra(VectorRoomInviteMembersActivity.EXTRA_ADD_CONFIRMATION_DIALOG, true);
 
-                if (DinsicUtils.isFederatedRoom(mRoom)) {
-                    if (TextUtils.equals(DinsicUtils.getRoomAccessRule(mRoom), RoomAccessRulesKt.RESTRICTED)) {
-                        intent.putExtra(VectorRoomInviteMembersActivity.EXTRA_CONTACTS_FILTER, VectorRoomInviteMembersActivity.ContactsFilter.ALL_WITHOUT_EXTERNALS);
+                if (DinumUtilsKt.isSecure()) {
+                    // Invite by email is not allowed in Tchap secure -> Consider only Tchap users.
+                    if (DinsicUtils.isFederatedRoom(mRoom)) {
+                        // All the rooms are restricted by default (or direct), there is no external users in Tchap secure
+                        // -> we use TCHAP_USERS_ONLY instead of TCHAP_USERS_ONLY_WITHOUT_EXTERNALS
+                        // This avoids us from checking whether a user is external or not (which is useless on Tchap secure).
+                        intent.putExtra(VectorRoomInviteMembersActivity.EXTRA_CONTACTS_FILTER, VectorRoomInviteMembersActivity.ContactsFilter.TCHAP_USERS_ONLY);
                     } else {
-                        intent.putExtra(VectorRoomInviteMembersActivity.EXTRA_CONTACTS_FILTER, VectorRoomInviteMembersActivity.ContactsFilter.ALL);
+                        intent.putExtra(VectorRoomInviteMembersActivity.EXTRA_CONTACTS_FILTER, VectorRoomInviteMembersActivity.ContactsFilter.TCHAP_USERS_ONLY_WITHOUT_FEDERATION);
                     }
                 } else {
-                    intent.putExtra(VectorRoomInviteMembersActivity.EXTRA_CONTACTS_FILTER, VectorRoomInviteMembersActivity.ContactsFilter.ALL_WITHOUT_FEDERATION);
+                    if (DinsicUtils.isFederatedRoom(mRoom)) {
+                        if (TextUtils.equals(DinsicUtils.getRoomAccessRule(mRoom), RoomAccessRulesKt.RESTRICTED)) {
+                            intent.putExtra(VectorRoomInviteMembersActivity.EXTRA_CONTACTS_FILTER, VectorRoomInviteMembersActivity.ContactsFilter.ALL_WITHOUT_EXTERNALS);
+                        } else {
+                            intent.putExtra(VectorRoomInviteMembersActivity.EXTRA_CONTACTS_FILTER, VectorRoomInviteMembersActivity.ContactsFilter.ALL);
+                        }
+                    } else {
+                        intent.putExtra(VectorRoomInviteMembersActivity.EXTRA_CONTACTS_FILTER, VectorRoomInviteMembersActivity.ContactsFilter.ALL_WITHOUT_FEDERATION);
+                    }
                 }
 
                 getActivity().startActivityForResult(intent, INVITE_USER_REQUEST_CODE);

--- a/vector/src/main/java/im/vector/fragments/VectorRoomSettingsFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorRoomSettingsFragment.java
@@ -529,6 +529,12 @@ public class VectorRoomSettingsFragment extends PreferenceFragment implements Sh
 
         // Handle the room access rules
         mRoomAccessRulePreference = findPreference(PREF_KEY_ROOM_ACCESS_RULE);
+        if (null != mRoomAccessRulePreference && DinumUtilsKt.isSecure()) {
+            // remove this option in Tchap-secure
+            PreferenceScreen preferenceScreen = getPreferenceScreen();
+            preferenceScreen.removePreference(mRoomAccessRulePreference);
+            mRoomAccessRulePreference = null;
+        }
 
         // init the room avatar: session and room
         mRoomPhotoAvatar.setConfiguration(mSession, mRoom);


### PR DESCRIPTION
Target = protecteed

- Hide the invite by email which is not supported in Tchap-secure
- Hide the room access rules settings. There is no external users in Tchap-secure, all the room are `restricted` or `direct` for the moment. This state event is handled automatically at the room creation on server side