### PR TITLE
Improve the notifications display on devices running API level < 24

### DIFF
--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -1510,6 +1510,8 @@ Si vous n’avez pas configuré de nouvelle méthode de récupération, un attaq
 
     <string name="action_mark_room_read">Marquer comme lu</string>
     <string name="settings_notification_privacy_no_background_sync">Les applications &lt;b&gt;n’&lt;/a&gt;ont &lt;b&gt;pas&lt;/b&gt; besoin d’être connectées au serveur d’accueil en arrière-plan, cela devrait diminuer l’utilisation de la batterie<b>not</b> need to connect to the HomeServer in the background, it should reduce battery usage</string>
+    <string name="notification_compat_summary_line_for_event">%1$s : %2$s « %3$s »</string>
+    <string name="notification_compat_summary_line_for_direct_event">%1$s : « %2$s »</string>
     <plurals name="notification_compat_summary_line_for_room">
         <item quantity="one">%1$s : 1 message</item>
         <item quantity="other">%1$s : %2$d messages</item>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1099,6 +1099,8 @@
         <item quantity="other">%d rooms</item>
     </plurals>
 
+    <string name="notification_compat_summary_line_for_event">%1$s: %2$s \"%3$s\"</string>
+    <string name="notification_compat_summary_line_for_direct_event">%1$s: \"%2$s\"</string>
     <plurals name="notification_compat_summary_line_for_room">
         <item quantity="one">%1$s: 1 message</item>
         <item quantity="other">%1$s: %2$d messages</item>


### PR DESCRIPTION
- Do not show a summary when only one notification is presented
- Display the event body in the summary when only one message is pending for a room
- Remove the "domain" of the sender display name
- Handle properly direct room