### PR TITLE
Bug Fix - Quick Reply: Handle correctly the failure on unknown devices

### DIFF
--- a/vector/src/main/java/im/vector/activity/LockScreenActivity.java
+++ b/vector/src/main/java/im/vector/activity/LockScreenActivity.java
@@ -225,7 +225,7 @@ public class LockScreenActivity extends VectorAppCompatActivity { // do NOT exte
                 Log.d(LOG_TAG, "Send message : onMatrixError " + e.getMessage());
 
                 if (e instanceof MXCryptoError) {
-                    Toast.makeText(LockScreenActivity.this, ((MXCryptoError) e).getDetailedErrorDescription(), Toast.LENGTH_SHORT).show();
+                    Toast.makeText(LockScreenActivity.this, R.string.notification_inline_reply_failed, Toast.LENGTH_SHORT).show();
                 } else {
                     Toast.makeText(LockScreenActivity.this, e.getLocalizedMessage(), Toast.LENGTH_SHORT).show();
                 }

--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -2680,11 +2680,10 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
             boolean hasUndeliverableEvents = (undeliveredEvents != null) && (undeliveredEvents.size() > 0);
             boolean hasUnknownDeviceEvents = (unknownDeviceEvents != null) && (unknownDeviceEvents.size() > 0);
 
-            //don't alert the user
-            // if (hasUndeliverableEvents || hasUnknownDeviceEvents) {
-            if (hasUndeliverableEvents) {
+            if (hasUndeliverableEvents || hasUnknownDeviceEvents) {
+                // Don't alert the user about the unknown devices, consider this is always undelivered events
                 mHasUnsentEvents = true;
-                state = new NotificationAreaView.State.UnsentEvents(hasUndeliverableEvents, hasUnknownDeviceEvents);
+                state = new NotificationAreaView.State.UnsentEvents(true, false);
             } else if ((null != mIsScrolledToTheBottom) && (!mIsScrolledToTheBottom)) {
                 int unreadCount = 0;
                 final RoomSummary summary = mRoom.getDataHandler().getStore().getSummary(mRoom.getRoomId());


### PR DESCRIPTION
TODO: fix the rendering of the error message in the toast displayed on devices running API < 24

<img width="423" alt="Screenshot 2020-06-12 at 10 42 00" src="https://user-images.githubusercontent.com/8969772/84483265-61435d80-ac99-11ea-8bf6-b467ac8a1bdb.png">

