### PR TITLE
Bug Fix - Some messages are stuck on decryption failure whereas the keys have been shared

### DIFF
--- a/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
+++ b/vector/src/main/java/im/vector/adapters/VectorMessagesAdapterHelper.java
@@ -1078,7 +1078,11 @@ class VectorMessagesAdapterHelper {
                 || Event.EVENT_TYPE_MESSAGE_ENCRYPTION.equals(eventType)) {
             // if we can display text for it, it's valid.
             EventDisplay display = new RiotEventDisplay(context);
-            return event.hasContentFields() && row.getText(null, display) != null;
+            boolean ret = event.hasContentFields() && row.getText(null, display) != null;
+            // Reset the temporary row message text (by updating the event)
+            // This is required to build the actual text message later.
+            row.updateEvent(event);
+            return ret;
         } else if (TextUtils.equals(WidgetsManager.WIDGET_EVENT_TYPE, event.getType())) {
             // Matrix apps are enabled
             return true;


### PR DESCRIPTION
 #594

We handle here correctly the case where the keys are requested again by the user.
During tests, we observed another case where the keys are requested automatically when the message is rendered for the first time (this case is fixed too)