### PR TITLE
Bug Fix: The sound is missing on some notifications

### DIFF
--- a/vector/src/main/java/im/vector/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/notifications/NotificationDrawerManager.kt
@@ -19,6 +19,7 @@ import android.app.Notification
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.os.Build
 import android.os.PowerManager
 import android.text.TextUtils
 import android.view.WindowManager
@@ -206,6 +207,10 @@ class NotificationDrawerManager(val context: Context) {
             var hasNewEvent = false
             var summaryIsNoisy = false
             val summaryInboxStyle = NotificationCompat.InboxStyle()
+            // Tchap: The summary prevents the user from seeing the messages when only one room is
+            // notified on devices running API level < 24.
+            // We added a patch to handle this case (see summaryLine use).
+            var summaryLine : String? = null
 
             //group events by room to create a single MessagingStyle notif
             val roomIdToEventMap: MutableMap<String, ArrayList<NotifiableMessageEvent>> = HashMap()
@@ -303,19 +308,22 @@ class NotificationDrawerManager(val context: Context) {
 
                 try {
                     if (events.size > 1) {
-                        val summaryLine = context.resources.getQuantityString(
+                        summaryLine = context.resources.getQuantityString(
                                 R.plurals.notification_compat_summary_line_for_room, events.size, roomName, events.size)
                         summaryInboxStyle.addLine(summaryLine)
                     } else if (events[0].roomIsDirect) {
-                        summaryInboxStyle.addLine(context.getString(R.string.notification_compat_summary_line_for_direct_event, roomName, events[0].body))
+                        summaryLine = context.getString(R.string.notification_compat_summary_line_for_direct_event, roomName, events[0].body)
+                        summaryInboxStyle.addLine(summaryLine)
                     } else {
                         val shortSenderName = DinsicUtils.getNameFromDisplayName(events[0].senderName)
-                        summaryInboxStyle.addLine(context.getString(R.string.notification_compat_summary_line_for_event, roomName, shortSenderName, events[0].body))
+                        summaryLine = context.getString(R.string.notification_compat_summary_line_for_event, roomName, shortSenderName, events[0].body)
+                        summaryInboxStyle.addLine(summaryLine)
                     }
                 } catch (e: Throwable) {
                     //String not found or bad format
                     Log.d(LOG_TAG, "%%%%%%%% REFRESH NOTIFICATION DRAWER failed to resolve string")
                     summaryInboxStyle.addLine(roomName)
+                    summaryLine = null
                 }
 
                 if (firstTime || roomGroup.hasNewEvent) {
@@ -374,21 +382,24 @@ class NotificationDrawerManager(val context: Context) {
                 NotificationUtils.cancelNotificationMessage(context, null, SUMMARY_NOTIFICATION_ID)
             } else {
                 val nbEvents = roomIdToEventMap.size + simpleEvents.size
-                // Do not show a summary when only one notification is displayed
-                // This fixes the display of this notification on devices running API level < 24.
-                if (nbEvents > 1) {
-                    val sumTitle = context.resources.getQuantityString(
+                // Patch: When only one notification is displayed on devices running API level < 24,
+                // We use the unique line of the summary as sumTitle (in order to display some details).
+                var sumTitle: String
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N && nbEvents == 1 && summaryLine != null) {
+                    sumTitle = summaryLine
+                } else {
+                    sumTitle = context.resources.getQuantityString(
                             R.plurals.notification_compat_summary_title, nbEvents, nbEvents)
-                    summaryInboxStyle.setBigContentTitle(sumTitle)
-                    NotificationUtils.buildSummaryListNotification(
-                            context,
-                            summaryInboxStyle,
-                            sumTitle,
-                            noisy = hasNewEvent && summaryIsNoisy,
-                            lastMessageTimestamp = globalLastMessageTimestamp
-                    )?.let {
-                        NotificationUtils.showNotificationMessage(context, null, SUMMARY_NOTIFICATION_ID, it)
-                    }
+                }
+                summaryInboxStyle.setBigContentTitle(sumTitle)
+                NotificationUtils.buildSummaryListNotification(
+                        context,
+                        summaryInboxStyle,
+                        sumTitle,
+                        noisy = hasNewEvent && summaryIsNoisy,
+                        lastMessageTimestamp = globalLastMessageTimestamp
+                )?.let {
+                    NotificationUtils.showNotificationMessage(context, null, SUMMARY_NOTIFICATION_ID, it)
                 }
 
                 if (hasNewEvent && summaryIsNoisy) {


### PR DESCRIPTION
This was due to our previous changes to improve notifications on devices running API level < 24.
Indeed the summary was preventing the user from seeing the messages when only one room is notified on devices running API level < 24. Our first correction broke the notification sound on all devices when only one notification is displayed.

We apply here another patch to display the unique summary line, instead of "1 Notification" on devices running API level < 24. And keep the existing code for other devices