### PR TITLE
Bug Fix: The notification sound is missing for the first one after backgrounding the app

### DIFF
--- a/vector/src/main/java/im/vector/notifications/NotificationDrawerManager.kt
+++ b/vector/src/main/java/im/vector/notifications/NotificationDrawerManager.kt
@@ -380,7 +380,7 @@ class NotificationDrawerManager(val context: Context) {
 
             if (eventList.isEmpty()) {
                 NotificationUtils.cancelNotificationMessage(context, null, SUMMARY_NOTIFICATION_ID)
-            } else {
+            } else if (firstTime || hasNewEvent) {
                 val nbEvents = roomIdToEventMap.size + simpleEvents.size
                 // Patch: When only one notification is displayed on devices running API level < 24,
                 // We use the unique line of the summary as sumTitle (in order to display some details).


### PR DESCRIPTION
This was due to the call of refreshNotificationDrawer in iconLoader callback.
This call refreshes the SummaryListNotification without sound because then `hasNewEvent` is false...
I decided to ignore this refresh for the moment to keep the sound