### PR TITLE
Fix email validation catch up:

### DIFF
--- a/vector/src/agent/AndroidManifest.xml
+++ b/vector/src/agent/AndroidManifest.xml
@@ -13,8 +13,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.dev-durable.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -25,8 +29,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.dinum.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -37,8 +45,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.intradef.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -49,8 +61,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.diplomatie.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -61,8 +77,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.justice.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -73,8 +93,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.agriculture.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -85,8 +109,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.interieur.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -97,8 +125,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.social.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -109,8 +141,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.education.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -121,8 +157,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.finances.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -133,8 +173,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.ssi.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -145,8 +189,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.pm.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -157,8 +205,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.elysee.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -169,8 +221,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.culture.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -181,8 +237,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -193,8 +253,28 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agent.collectivites.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="matrix.agent.externe.tchap.gouv.fr" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/vector/src/main/java/im/vector/LoginHandler.java
+++ b/vector/src/main/java/im/vector/LoginHandler.java
@@ -217,7 +217,8 @@ public class LoginHandler {
                                            final ApiCallback<Boolean> aRespCallback) {
         ThirdPidRestClient restClient = new ThirdPidRestClient(aHomeServerConfig);
 
-        restClient.submitValidationToken(
+        // Tchap: submitValidationToken returns an error 403 on Tchap server - We force the legacy version for the moment
+        restClient.submitValidationTokenLegacy(
                 ThreePid.MEDIUM_EMAIL,
                 aToken,
                 aClientSecret,

--- a/vector/src/main/java/im/vector/util/BugReporter.java
+++ b/vector/src/main/java/im/vector/util/BugReporter.java
@@ -286,7 +286,7 @@ public class BugReporter {
                     }
 
                     // tag Tchap bug reports to better triage them
-                    builder.addFormDataPart("label", "dinsic");
+                    builder.addFormDataPart("label", "DINUM");
 
                     BugReporterMultipartBody requestBody = builder.build();
 

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -914,6 +914,9 @@ Appareils inconnus :</string>
     <string name="tchap_register_unauthorized_email">Cette adresse e-mail n’est pas autorisée</string>
     <string name="tchap_password_weak_pwd_error">Ce mot de passe est trop faible. Il doit contenir au moins 8 caractères, avec au moins un caractère de chaque type : majuscule, minuscule, chiffre, caractère spécial.</string>
     <string name="tchap_password_pwd_in_dict_error">Ce mot de passe a été trouvé dans un dictionnaire, il n’est pas autorisé</string>
+    <string name="tchap_register_user_already_logged_in_prompt">Il semblerait que vous essayez de vous connecter avec un autre compte. Voulez-vous vous déconnecter \?</string>
+    <string name="tchap_email_validation_succeeded">Votre email a été validé, vous pouvez poursuivre l’opération qui attendait cette validation.</string>
+    <string name="tchap_email_validation_failed">La validation de l’email a échouée. Le lien a expiré, ou il n’est pas valide.</string>
 
     <string name="tchap_change_password_help">Votre nouveau mot de passe doit contenir au moins 8 caractères, avec au moins un caractère de chaque type : majuscule, minuscule, chiffre, caractère spécial.</string>
 

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1341,6 +1341,9 @@
     <string name="tchap_register_unauthorized_email">This email address is unauthorized</string>
     <string name="tchap_password_weak_pwd_error">This password is too weak. It must include a lower-case letter, an upper-case letter, a number and a symbol and be at a minimum 8 characters in length.</string>
     <string name="tchap_password_pwd_in_dict_error">This password was found in a dictionary, and is not acceptable</string>
+    <string name="tchap_register_user_already_logged_in_prompt">It looks like you’re trying to connect with another account. Do you want to sign out?</string>
+    <string name="tchap_email_validation_succeeded">The email has been validated. You may pursue the related operation.</string>
+    <string name="tchap_email_validation_failed">The email validation failed. The link has expired, or it is not valid.</string>
 
     <string name="tchap_change_password_help">Your new password must include a lower-case letter, an upper-case letter, a number and a symbol and be at a minimum 8 characters in length.</string>
 

--- a/vector/src/preprod/AndroidManifest.xml
+++ b/vector/src/preprod/AndroidManifest.xml
@@ -13,8 +13,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.i.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -25,8 +29,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.e.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/vector/src/protecteed/AndroidManifest.xml
+++ b/vector/src/protecteed/AndroidManifest.xml
@@ -13,8 +13,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.dev-durable.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -25,8 +29,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.dinum.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -37,8 +45,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.intradef.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -49,8 +61,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.diplomatie.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -61,8 +77,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.justice.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -73,8 +93,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.agriculture.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -85,8 +109,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.interieur.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -97,8 +125,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.social.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -109,8 +141,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.education.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -121,8 +157,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.finances.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -133,8 +173,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.ssi.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -145,8 +189,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.pm.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -157,8 +205,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.elysee.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -169,8 +221,12 @@
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:host="matrix.culture.tchap.gouv.fr" />
-                <!-- mail validation -->
-                <data android:pathPrefix="/_matrix/" />
+                <!-- email validation, account renew -->
+                <data android:pathPrefix="/_matrix/client/unstable/registration/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/password_reset/email/submit_token" />
+                <data android:pathPrefix="/_matrix/client/unstable/account_validity/renew" />
+                <!-- legacy email validation -->
+                <data android:pathPrefix="/_matrix/identity/api/v1/validate/email/submitToken" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
- Universal links: update the listed url paths to limit them to the supported ones
- Support now the email validation process with Synapse (registration and password_reset only)
- Pursue the account creation (or password reset) in Login Activity
- TchapLoginActivity: Do not stop loading wheel on registration flow update - the registration is still in progress (for Tchap)
