### PR TITLE
VoIP hide the call icon when the user is the only one joined member, and there is no more than 1 invite

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -2713,7 +2713,9 @@ public class VectorRoomActivity extends MXCActionBarActivity implements
      */
     private void refreshCallButtons(boolean refreshOngoingConferenceCallView) {
         if ((null == sRoomPreviewData) && (null == mEventId) && (null == mTchapUser) && canSendMessages()) {
-            boolean isCallSupported = mRoom.canPerformCall() && mSession.isVoipCallSupported();
+            boolean isCallSupported = mRoom.canPerformCall()
+                    && mSession.isVoipCallSupported()
+                    && (mRoom.getNumberOfMembers() > 2 || mRoom.getNumberOfJoinedMembers() == 2);
             IMXCall call = CallsManager.getSharedInstance().getActiveCall();
             Widget activeWidget = mVectorOngoingConferenceCallView.getActiveWidget();
 


### PR DESCRIPTION
The icon is displayed when there are 2 joined members, or more than 3 members (joined and invited members)

#615 