### PR TITLE
Bug Fix: [Expired Account] Tchap is stuck on the splash screen whereas the account is renewed

### DIFF
--- a/TCHAP_CHANGES.rst
+++ b/TCHAP_CHANGES.rst
@@ -5,6 +5,7 @@ Bug Fixes:
  * Configure correctly activity launchmode PR #630
  * Fix searchview cursor color PR #633
  * fix crash loop back off on invalid access token #636
+ * [Expired Account] Tchap is stuck on the splash screen whereas the account is renewed #639
  
  Changes in Tchap 1.0.46 (2020-09-26)
 ===================================================


### PR DESCRIPTION
Force a restart if the currentSyncToken is null whereas the store is ready.

#639 