### PR TITLE
[Room access] Improve the wording related to the room link access

### DIFF
--- a/TCHAP_CHANGES.rst
+++ b/TCHAP_CHANGES.rst
@@ -6,6 +6,7 @@ Improvements:
  * Private rooms: turn on the option to join on room’s link #573
  * Room preview: we have to support the preview on shared room link #612
  * [Room creation] Do not override the power levels anymore #632
+ * [Room access] Improve the wordings related to the room link access #645
 
 Bug Fixes:
  * Tchap crashes on invalid access token #631

--- a/vector/src/main/java/fr/gouv/tchap/activity/TchapRoomAccessByLinkActivity.kt
+++ b/vector/src/main/java/fr/gouv/tchap/activity/TchapRoomAccessByLinkActivity.kt
@@ -148,6 +148,7 @@ class TchapRoomAccessByLinkActivity : VectorAppCompatActivity(){
         var isAdmin = false
         val isConnected = Matrix.getInstance(this).isConnected
         val joinRule: String = room.state.join_rule
+        val accessRule = DinsicUtils.getRoomAccessRule(room)
         val powerLevels: PowerLevels = room.state.powerLevels
         if (null != powerLevels) {
             val powerLevel = powerLevels.getUserPowerLevel(session.myUserId)
@@ -172,7 +173,11 @@ class TchapRoomAccessByLinkActivity : VectorAppCompatActivity(){
         } else {
             roomAccessByLinkStatus.text = getString(R.string.tchap_room_settings_room_access_by_link_enabled)
             switchRoomAccessByLink.isChecked = true
-            roomAccessByLinkInfo.text = getString(R.string.tchap_room_settings_enable_room_access_by_link_info_on)
+            if (accessRule == RESTRICTED) {
+                roomAccessByLinkInfo.text = getString(R.string.tchap_room_settings_enable_room_access_by_link_info_on)
+            } else {
+                roomAccessByLinkInfo.text = getString(R.string.tchap_room_settings_enable_room_access_by_link_info_on_with_limitation)
+            }
             roomAccessLink.text = createPermalink(getString(R.string.permalink_prefix), room.state.canonicalAlias)
             roomAccessLink.visibility = View.VISIBLE
             buttonsContainer.visibility = View.VISIBLE

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -882,6 +882,7 @@ Appareils inconnus :</string>
     <string name="tchap_room_settings_enable_room_access_by_link">Activer l’accès au salon par lien</string>
     <string name="tchap_room_settings_enable_room_access_by_link_info_off">Les autres utilisateurs seront autorisés à rejoindre ce salon à partir d’un lien</string>
     <string name="tchap_room_settings_enable_room_access_by_link_info_on">Les autres utilisateurs peuvent rejoindre ce salon à partir du lien suivant\u00A0:</string>
+    <string name="tchap_room_settings_enable_room_access_by_link_info_on_with_limitation">Les autres utilisateurs peuvent rejoindre ce salon à partir du lien suivant (une invitation reste nécessaire pour les externes)\u00A0:</string>
     <string name="tchap_room_settings_room_access_by_link_forward">Transférer le lien</string>
     <string name="tchap_room_settings_room_access_by_link_share">Partager le lien</string>
     <string name="tchap_room_settings_room_access_by_link_forbidden">Ce changement n’est pas supporté actuellement car les externes sont autorisés à rejoindre ce salon. Il sera supporté prochainement</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1310,6 +1310,7 @@
     <string name="tchap_room_settings_enable_room_access_by_link">Enable the room access by link</string>
     <string name="tchap_room_settings_enable_room_access_by_link_info_off">Users will be allowed to join the room from a link</string>
     <string name="tchap_room_settings_enable_room_access_by_link_info_on">Users can join the room from the following link:</string>
+    <string name="tchap_room_settings_enable_room_access_by_link_info_on_with_limitation">Users can join the room from the following link (an invite is still required for externals):</string>
     <string name="tchap_room_settings_room_access_by_link_forward">Forward the link</string>
     <string name="tchap_room_settings_room_access_by_link_share">Share the link</string>
     <string name="tchap_room_settings_room_access_by_link_forbidden">This change is currently forbidden when externals are allowed to join the room</string>


### PR DESCRIPTION
In case of a private room opened to the external users, we have to notify the admins when they turn on the access by link that the external users will still require an invite to join.

#645 