### PR TITLE
Attachments: an empty bubble is displayed for the infected attachments

### DIFF
--- a/vector/src/main/res/layout/adapter_item_tchap_media_scan.xml
+++ b/vector/src/main/res/layout/adapter_item_tchap_media_scan.xml
@@ -87,7 +87,7 @@
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/messagesAdapter_media_layout"
-                        android:layout_width="wrap_content"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content">
 
                         <View


### PR DESCRIPTION
#637 