### PR TITLE
Bug Fix: [Android 10] permission denied to open a pdf

### DIFF
--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -76,6 +76,7 @@
         android:resizeableActivity="false"
         android:supportsRtl="true"
         android:theme="@style/AppTheme.Light"
+        android:requestLegacyExternalStorage="true"
         tools:replace="allowBackup,label">
 
         <!-- No limit for screen ratio: avoid black strips -->


### PR DESCRIPTION
Apps that target Android 10 (API level 29) can still request the requestLegacyExternalStorage attribute. This flag allows apps to temporarily opt out of the changes associated with scoped storage, such as granting access to different directories and different types of media files.

TODO use Scoped Storage

#683