### PR TITLE
Define a minimum size for the passphrase used to encrypt the exported keys file

### DIFF
--- a/TCHAP_CHANGES.rst
+++ b/TCHAP_CHANGES.rst
@@ -4,6 +4,7 @@ Changes in Tchap 1.x.x (2021-xx-xx)
 Improvements:
  * Apply the design for the specific Tchap Info room #718
  * Apply the new design of the Room header PR #713
+ * Define a minimum size for the passphrase used to encrypt the exported keys file #712
 
 Bug Fixes:
  *

--- a/vector/src/main/java/im/vector/dialogs/ExportKeysDialog.kt
+++ b/vector/src/main/java/im/vector/dialogs/ExportKeysDialog.kt
@@ -49,7 +49,7 @@ class ExportKeysDialog {
 
             override fun afterTextChanged(s: Editable) {
                 when {
-                    TextUtils.isEmpty(passPhrase1EditText.text)                          -> {
+                    TextUtils.isEmpty(passPhrase1EditText.text) || passPhrase1EditText.length() < 8 -> {
                         exportButton.isEnabled = false
                         passPhrase2Til.error = null
                     }

--- a/vector/src/main/res/values-fr/strings.xml
+++ b/vector/src/main/res/values-fr/strings.xml
@@ -1181,7 +1181,7 @@ Veuillez noter que cette action redémarrera l’application et pourra prendre u
     <string name="status_theme">Thème Status.im</string>
 
     <string name="room_sliding_menu_version_x">Version %s</string>
-    <string name="encryption_export_notice">Veuillez créer une phrase secrète pour chiffrer les clés exportées. Vous devrez saisir cette même phrase secrète afin de pouvoir importer les clés.</string>
+    <string name="encryption_export_notice">Veuillez créer une phrase secrète pour chiffrer les clés exportées. Elle doit contenir au moins 8 caractères. Vous devrez saisir cette phrase secrète lors de l’importation des clés.</string>
     <string name="passphrase_create_passphrase">Créer la phrase secrète</string>
     <string name="passphrase_passphrase_does_not_match">Les phrases secrètes doivent concorder</string>
     <string name="merged_events_expand">afficher</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -1038,7 +1038,7 @@
     <string name="encryption_export_room_keys">Export room keys</string>
     <string name="encryption_export_room_keys_summary">Export the keys to a local file</string>
     <string name="encryption_export_export">Export</string>
-    <string name="encryption_export_notice">Please create a passphrase to encrypt the exported keys. You will need to enter the same passphrase to be able to import the keys.</string>
+    <string name="encryption_export_notice">Please create a passphrase to encrypt the exported keys. It must be at a minimum 8 characters in length. You will need to enter the same passphrase to be able to import the keys.</string>
     <string name="encryption_export_saved_as">The E2E room keys have been saved to \'%s\'.\n\nWarning: this file may be deleted if the application is uninstalled.</string>
 
     <string name="encryption_message_recovery">Encrypted Messages Recovery</string>


### PR DESCRIPTION
#712 

here is the updated dialog:
![image](https://user-images.githubusercontent.com/8969772/119342023-c6b71100-bc94-11eb-82d8-f4e02184b974.png)
